### PR TITLE
feat: implements time complete from tesseract annotations

### DIFF
--- a/src/api/tesseract/parse.ts
+++ b/src/api/tesseract/parse.ts
@@ -36,7 +36,8 @@ export function queryParamsToRequest(params: QueryParams): TesseractDataRequest 
       item.active ? filterSerialize(item) : null
     ).join(","),
     limit: `${params.pagiLimit || 0},${params.pagiOffset || 0}`,
-    sort: params.sortKey ? `${params.sortKey}.${params.sortDir}` : undefined
+    sort: params.sortKey ? `${params.sortKey}.${params.sortDir}` : undefined,
+    time: params.timeComplete ? `${params.timeComplete}.complete` : undefined
     // sparse: params.sparse,
     // ranking:
     //   typeof params.ranking === "boolean"
@@ -108,6 +109,8 @@ export function requestToQueryParams(cube: TesseractCube, search: URLSearchParam
   const [limit = "0", offset = "0"] = (search.get("limit") || "0").split(",");
   const [sortKey, sortDir] = (search.get("sort") || "").split(".");
 
+  const timeComplete = search.get("time")?.split(".")[0] || undefined;
+
   return {
     cube: cube.name,
     locale: search.get("locale") || undefined,
@@ -120,6 +123,7 @@ export function requestToQueryParams(cube: TesseractCube, search: URLSearchParam
     sortDir: sortDir === "asc" ? "asc" : "desc",
     sortKey: sortKey || undefined,
     isPreview: false,
+    timeComplete: timeComplete || undefined,
     booleans: {
       // parents: search.get("parents") || undefined,
     }

--- a/src/components/TableView.tsx
+++ b/src/components/TableView.tsx
@@ -97,7 +97,7 @@ function isColumnSorted(column: string, key: string) {
 
 const removeColumn = (
   queryItem: QueryItem,
-  entity: TesseractMeasure | TesseractProperty | TesseractLevel,
+  entity: TesseractMeasure | TesseractProperty | TesseractLevel
 ) => {
   const newQuery = buildQuery(cloneDeep(queryItem));
   const params = newQuery.params;
@@ -122,15 +122,15 @@ const removeColumn = (
     const mapPropertyToDrilldown = Object.fromEntries(
       Object.values(params.drilldowns)
         .filter(drilldown => drilldown.active)
-        .flatMap(drilldown => drilldown.properties.map(prop => [prop.name, drilldown])),
+        .flatMap(drilldown => drilldown.properties.map(prop => [prop.name, drilldown]))
     );
     const drilldown = mapPropertyToDrilldown[entity.name];
     if (drilldown) {
       params.drilldowns[drilldown.key] = {
         ...drilldown,
         properties: drilldown.properties.map(prop =>
-          prop.name === entity.name ? {...prop, active: false} : prop,
-        ),
+          prop.name === entity.name ? {...prop, active: false} : prop
+        )
       };
       return newQuery;
     }

--- a/src/context/query.tsx
+++ b/src/context/query.tsx
@@ -183,7 +183,8 @@ export function QueryProvider({children, defaultCube}: QueryProviderProps) {
   };
 
   function setDefaultValues(cube: TesseractCube) {
-    const drilldowns = pickDefaultDrilldowns(cube.dimensions, cube).map(level =>
+    const {levels, timeComplete} = pickDefaultDrilldowns(cube.dimensions, cube);
+    const drilldowns = levels.map(level =>
       buildDrilldown({
         ...level,
         key: level.name,
@@ -213,7 +214,8 @@ export function QueryProvider({children, defaultCube}: QueryProviderProps) {
         cube: cube.name,
         measures: keyBy(measures, item => item.key),
         drilldowns: keyBy(drilldowns, item => item.key),
-        locale
+        locale,
+        timeComplete
       },
       panel: panel ?? "table"
     });

--- a/src/hooks/permalink.tsx
+++ b/src/hooks/permalink.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect} from "react";
+import {useCallback} from "react";
 import type {TesseractCube} from "../api";
 import {queryParamsToRequest, requestToQueryParams} from "../api/tesseract/parse";
 import {selectCurrentQueryItem} from "../state/queries";

--- a/src/state/queries.ts
+++ b/src/state/queries.ts
@@ -127,6 +127,10 @@ export const queriesSlice = createSlice({
       delete query.params.filters[action.payload];
     },
 
+    removeTimeComplete(state) {
+      const query = taintCurrentQuery(state);
+      delete query.params.timeComplete;
+    },
     /**
      * Replaces multiple QueryParams for the current QueryItem at once.
      */
@@ -234,6 +238,15 @@ export const queriesSlice = createSlice({
     },
 
     /**
+     * Replaces the timeComplete value in the current QueryItem.
+     */
+    updateTimeComplete(state, {payload}: Action<string>) {
+      const query = taintCurrentQuery(state);
+      if (payload !== query.params.timeComplete) {
+        query.params.timeComplete = payload;
+      }
+    },
+    /**
      * Replaces a single FilterItem in the current QueryItem.
      */
     updateFilter(state, {payload}: Action<FilterItem>) {
@@ -247,7 +260,6 @@ export const queriesSlice = createSlice({
     updateLocale(state, {payload}: Action<string>) {
       const query = state.itemMap[state.current];
       if (payload !== query.params.locale) {
-        // query.isDirty = true;
         query.params.locale = payload;
       }
     },

--- a/src/utils/structs.ts
+++ b/src/utils/structs.ts
@@ -28,6 +28,7 @@ export interface QueryParams {
   pagiOffset: number;
   sortDir: "asc" | "desc";
   sortKey: string | undefined;
+  timeComplete: string | undefined;
 }
 
 export interface QueryResult<D = Record<string, unknown>> {
@@ -159,7 +160,8 @@ export function buildQueryParams(props): QueryParams {
     pagiLimit: props.pagiLimit || props.limitAmount || props.limit || 100,
     pagiOffset: props.pagiOffset || props.limitOffset || props.offset || 0,
     sortDir: props.sortDir || props.sortDirection || props.sortOrder || props.order || "desc",
-    sortKey: props.sortKey || props.sortProperty || ""
+    sortKey: props.sortKey || props.sortProperty || "",
+    timeComplete: props.timeComplete || undefined
   };
 }
 


### PR DESCRIPTION
Implements time complete behavior in the Data Explorer:
- Adds `time={Drilldown}.complete` to default time level if the dimension annotation is active.
- Implements logic to derive the `{Drilldown}.complete` parameter in the right side panel.

```html
on a dimension:
<Annotation name="de_time_complete">true</Annotation>
```